### PR TITLE
Fix the display of the "AnyDesk" title on the OCS console

### DIFF
--- a/cd_anydesk/cd_anydesk.php
+++ b/cd_anydesk/cd_anydesk.php
@@ -19,7 +19,7 @@ if(AJAX){
     $ajax=false;
 }
 
-print_item_header($l->g(25000));
+print_item_header($l->g(28000));
 
 if (!isset($protectedPost['SHOW'])){
     $protectedPost['SHOW'] = 'NOSHOW';

--- a/hook.xml
+++ b/hook.xml
@@ -6,7 +6,7 @@
     </hook>
     <hook type="cdentry">
         <identifier>cd_anydesk</identifier>
-        <translation>25000</translation>
+        <translation>28000</translation>
         <category>other</category>
         <available>anydesk</available>
     </hook>

--- a/language/en_GB/en_GB.txt
+++ b/language/en_GB/en_GB.txt
@@ -1,1 +1,1 @@
-25000 Anydesk
+28000 Anydesk

--- a/language/fr_FR/fr_FR.txt
+++ b/language/fr_FR/fr_FR.txt
@@ -1,1 +1,1 @@
-25000 Anydesk
+28000 Anydesk


### PR DESCRIPTION
Hello, this is a Fix the display of the "AnyDesk" title on the OCS console, which previously displayed "Teamviewer" (due to the identical Language ID between the two modules).

(change the id 25000 to 28000)